### PR TITLE
Fix unexpected token limit and list option display (+feature to display api fee)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This package uses the power of OpenAI's GPT-3 model to understand your code chan
 
 `--force`: Automatically create a commit without being prompted to select a message (can't be used with `--list`)
 
+`--filter-fee`: Displays the approximate fee for using the API and prompts you to confirm the request
+
 `--apiKey`: Your OpenAI API key. It is not recommended to pass `apiKey` here, it is better to use `env` variable
 
 ## Contributing

--- a/filterApi.js
+++ b/filterApi.js
@@ -1,0 +1,16 @@
+import { encode } from 'gpt-3-encoder';
+
+const MAX_TOKENS = 4000;
+
+function filterApi(prompt) {
+    const numTokens = encode(prompt).length;
+
+    if (numTokens > MAX_TOKENS) {
+        console.log("The commit diff is too large for the ChatGPT API. Max 4k tokens or ~8k characters. ");
+        return false;
+    }
+
+    return true;
+};
+
+export { filterApi }

--- a/filterApi.js
+++ b/filterApi.js
@@ -1,13 +1,31 @@
 import { encode } from 'gpt-3-encoder';
+import inquirer from "inquirer";
 
+const FEE_PER_1K_TOKENS = 0.02;
 const MAX_TOKENS = 4000;
+//this is the approximate cost of a completion (answer) fee from CHATGPT
+const FEE_COMPLETION = 0.001;
 
-function filterApi(prompt) {
+async function filterApi({ prompt, numCompletion = 1, filterFee }) {
     const numTokens = encode(prompt).length;
+    const fee = numTokens / 1000 * FEE_PER_1K_TOKENS + (FEE_COMPLETION * numCompletion);
 
     if (numTokens > MAX_TOKENS) {
         console.log("The commit diff is too large for the ChatGPT API. Max 4k tokens or ~8k characters. ");
         return false;
+    }
+
+    if (filterFee) {
+        console.log(`This will cost you ~$${+fee.toFixed(3)} for using the API.`);
+        const answer = await inquirer.prompt([
+            {
+                type: "confirm",
+                name: "continue",
+                message: "Do you want to continue 💸?",
+                default: true,
+            },
+        ]);
+        if (!answer.continue) return false;
     }
 
     return true;

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ const generateSingleCommit = async (diff) => {
     "I want you to act as the author of a commit message in git. I'll enter a git diff, and your job is to convert it into a useful commit message. Do not preface the commit with anything, use the present tense, return the full sentence, and use the conventional commit convention with type written in lowercase:"
     + diff;
 
-  if (!filterApi(prompt)) process.exit(1);
+  if (!await filterApi({ prompt, filterFee: args['filter-fee'] })) process.exit(1);
 
   const { text } = await api.sendMessage(prompt);
 
@@ -70,7 +70,7 @@ const generateListCommits = async (diff) => {
     "I want you to act as the author of a commit message in git. I'll enter a git diff, and your job is to convert it into a useful commit message and make 5 comma-separated options.For each option, use the present tense, return the full sentence, and use the regular commit convention:"
     + diff;
 
-  if (!filterApi(prompt)) process.exit(1);
+  if (!await filterApi({ prompt, filterFee: args['filter-fee'] })) process.exit(1);
 
   const { text } = await api.sendMessage(prompt);
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ import { execSync } from "child_process";
 import { ChatGPTAPI } from "chatgpt";
 import inquirer from "inquirer";
 import { getArgs } from "./helpers.js";
-import { addGitmojiToCommitMessage } from './gitmoji.js'
+import { addGitmojiToCommitMessage } from './gitmoji.js';
+import { filterApi } from "./filterApi.js";
 
 const args = getArgs();
 
@@ -30,8 +31,11 @@ const makeCommit = (input) => {
 const generateSingleCommit = async (diff) => {
   const prompt =
     "I want you to act as the author of a commit message in git. I'll enter a git diff, and your job is to convert it into a useful commit message. Do not preface the commit with anything, use the present tense, return the full sentence, and use the conventional commit convention with type written in lowercase:"
+    + diff;
 
-  const { text } = await api.sendMessage(prompt + diff);
+  if (!filterApi(prompt)) process.exit(1);
+
+  const { text } = await api.sendMessage(prompt);
 
   const gitmojiCommit = addGitmojiToCommitMessage(text);
 
@@ -64,8 +68,11 @@ const generateSingleCommit = async (diff) => {
 const generateListCommits = async (diff) => {
   const prompt =
     "I want you to act as the author of a commit message in git. I'll enter a git diff, and your job is to convert it into a useful commit message and make 5 comma-separated options.For each option, use the present tense, return the full sentence, and use the regular commit convention:"
+    + diff;
 
-  const { text } = await api.sendMessage(prompt + diff);
+  if (!filterApi(prompt)) process.exit(1);
+
+  const { text } = await api.sendMessage(prompt);
 
   const msgs = text.split(",").map((msg) => msg.trim()).map(msg => addGitmojiToCommitMessage(msg));
 

--- a/index.js
+++ b/index.js
@@ -30,7 +30,9 @@ const makeCommit = (input) => {
 
 const generateSingleCommit = async (diff) => {
   const prompt =
-    "I want you to act as the author of a commit message in git. I'll enter a git diff, and your job is to convert it into a useful commit message. Do not preface the commit with anything, use the present tense, return the full sentence, and use the conventional commit convention with type written in lowercase:"
+    "I want you to act as the author of a commit message in git."
+    + "I'll enter a git diff, and your job is to convert it into a useful commit message."
+    + "Do not preface the commit with anything, use the present tense, return the full sentence, and use the conventional commit convention with type written in lowercase:"
     + diff;
 
   if (!await filterApi({ prompt, filterFee: args['filter-fee'] })) process.exit(1);
@@ -65,16 +67,18 @@ const generateSingleCommit = async (diff) => {
   makeCommit(gitmojiCommit);
 };
 
-const generateListCommits = async (diff) => {
+const generateListCommits = async (diff, numOptions = 5) => {
   const prompt =
-    "I want you to act as the author of a commit message in git. I'll enter a git diff, and your job is to convert it into a useful commit message and make 5 comma-separated options.For each option, use the present tense, return the full sentence, and use the regular commit convention:"
+    "I want you to act as the author of a commit message in git."
+    + `I'll enter a git diff, and your job is to convert it into a useful commit message and make ${numOptions} options that are separated by ";".`
+    + "For each option, use the present tense, return the full sentence, and use the regular commit convention:"
     + diff;
 
-  if (!await filterApi({ prompt, filterFee: args['filter-fee'] })) process.exit(1);
+  if (!await filterApi({ prompt, filterFee: args['filter-fee'], numCompletion: numOptions })) process.exit(1);
 
   const { text } = await api.sendMessage(prompt);
 
-  const msgs = text.split(",").map((msg) => msg.trim()).map(msg => addGitmojiToCommitMessage(msg));
+  const msgs = text.split(";").map((msg) => msg.trim()).map(msg => addGitmojiToCommitMessage(msg));
 
   // add regenerate option
   msgs.push(REGENERATE_MSG);

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "homepage": "https://github.com/insulineru/ai-commit#readme",
   "dependencies": {
     "chatgpt": "^4.2.0",
+    "gpt-3-encoder": "^1.1.4",
     "inquirer": "^9.1.4"
   }
 }


### PR DESCRIPTION
## Fixes 
- Unexpected token limit (If commit diff is greater than ~8k characters)
- Incorrect display of options in the message list (due to an extra comma that may be part of the chatgpt response/commit)
## Features
- `filter-fee` option to display the api fee and prompts you to confirm the request