### PR TITLE
✨ feat: add checkGitRepository function

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -1,3 +1,5 @@
+import { execSync } from "child_process";
+
 const getArgs = () => {
   const args = process.argv.slice(2);
   const result = {};
@@ -17,4 +19,13 @@ const getArgs = () => {
   return result;
 };
 
-export { getArgs }
+const checkGitRepository = () => {
+  try {
+    const output = execSync('git rev-parse --is-inside-work-tree', { encoding: 'utf-8' });
+    return output.trim() === 'true';
+  } catch (err) {
+    return false;
+  }
+};
+
+export { getArgs, checkGitRepository }

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 import { execSync } from "child_process";
 import { ChatGPTAPI } from "chatgpt";
 import inquirer from "inquirer";
-import { getArgs } from "./helpers.js";
+import { getArgs, checkGitRepository } from "./helpers.js";
 import { addGitmojiToCommitMessage } from './gitmoji.js';
 import { filterApi } from "./filterApi.js";
 
@@ -104,6 +104,13 @@ const generateListCommits = async (diff, numOptions = 5) => {
 };
 
 async function generateAICommit() {
+  const isGitRepository = checkGitRepository();
+
+  if (!isGitRepository) {
+    console.error("This is not a git repository 🙅‍♂️");
+    process.exit(1);
+  }
+
   const diff = execSync("git diff --staged").toString();
 
   // Handle empty diff


### PR DESCRIPTION
This commit adds the `checkGitRepository` function to the `helpers.js` module which checks if the current directory is a Git repository using the `git rev-parse --is-inside-work-tree` command. If it's not a Git repository, an error message will be logged to the console and the process will exit with code 1. The `checkGitRepository` function is exported from the module along with the `getArgs` function.

Additionally, this commit modifies the `index.js` module to import `checkGitRepository` from `helpers.js`. The `generateAICommit` function now calls `checkGitRepository` before executing the `git diff --staged` command and logs an error message if it returns false.