### PR TITLE
Fixed a issue that gitmoji was not selected correctly

### DIFF
--- a/gitmoji.js
+++ b/gitmoji.js
@@ -10,12 +10,14 @@ function addGitmojiToCommitMessage(commitMessage) {
     chore: "🔧",
   };
 
-  // Split the commit message into its parts
-  const [type, ...rest] = commitMessage.split(": ");
+  // Extract the first alphabetic character of the commit message
+  const match = commitMessage.match(/[a-zA-Z]+/);
+  if(!match) return commitMessage;
+  const type = match[0];
 
   // If the type is valid, add the corresponding gitmoji to the message
   if (typeToGitmoji[type]) {
-    return `${typeToGitmoji[type]} ${type}: ${rest.join(": ")}`;
+    return `${typeToGitmoji[type]} ${commitMessage}`;
   } else {
     // If the type is not recognized, return the original message
     return commitMessage;


### PR DESCRIPTION
## Issue

The `addGitmojiToCommitMessage` function fails to correctly identify the commit type when the commit message includes a scope (e.g., `fix(gitmoji)`).
This issue prevents accurate mapping of commit types to corresponding gitmojis

## Root Cause

This function does not account for cases where the commit message contains a scope in parentheses before the colon.

## Solution

Modified to use regular expression (`/[a-zA-Z]+/`) to extract the commit type of commit messages.