### PR TITLE
Refactor AI_PROVIDER Handling in index.js

### DIFF
--- a/ollama.js
+++ b/ollama.js
@@ -1,0 +1,64 @@
+const ollama = {
+  /**
+   * send prompt to ai.
+   */
+  sendMessage: async (input, { apiKey, model }) => {
+    //mistral as default since it's fast and clever model
+    const url = "http://127.0.0.1:11434/api/generate";
+    const data = {
+      model: model || 'mistral',
+      prompt: input,
+      stream: false,
+    };
+    console.log("prompting ollama...", url, model);
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        body: JSON.stringify(data),
+        headers: {
+          "Content-Type": "application/json",
+          // 'Content-Type': 'application/x-www-form-urlencoded',
+        },
+      });
+      const responseJson = await response.json();
+      const answer = responseJson.response;
+      console.log("response: ", answer);
+      console.log("prompting ai done!");
+      return answer;
+    } catch (err) {
+      console.log(err);
+      throw new Error("local model issues. details:" + err.message);
+    }
+  },
+
+  getPromptForSingleCommit: (diff, { commitType, language }) => {
+    return (
+      `Summarize this git diff into a useful, 10 words commit message in ${language}` +
+      (commitType ? ` with commit type '${commitType}.'` : "") +
+      ": " +
+      diff
+    );
+  },
+
+  getPromptForMultipleCommits: (
+    diff,
+    { commitType, numOptions, language }
+  ) => {
+    const prompt =
+      "I want you to act as the author of a commit message in git." +
+      `I'll enter a git diff, and your job is to convert it into a useful commit message in ${language} language` +
+      (commitType ? ` with commit type '${commitType}.', ` : ", ") +
+      `and make ${numOptions} options that are separated by ";".` +
+      "For each option, use the present tense, return the full sentence, and use the conventional commits specification (<type in lowercase>: <subject>):" +
+      diff;
+
+    return prompt;
+  },
+
+  filterApi: ({ prompt, numCompletion = 1, filterFee }) => {
+    //ollama dont have any limits and is free so we dont need to filter anything
+    return true;
+  }
+};
+
+export default ollama;

--- a/openai.js
+++ b/openai.js
@@ -1,0 +1,79 @@
+import { ChatGPTAPI } from "chatgpt";
+
+import { encode } from 'gpt-3-encoder';
+import inquirer from "inquirer";
+import { AI_PROVIDER } from "./config.js"
+
+const FEE_PER_1K_TOKENS = 0.02;
+const MAX_TOKENS = 128000;
+//this is the approximate cost of a completion (answer) fee from CHATGPT
+const FEE_COMPLETION = 0.001;
+
+const openai = {
+  sendMessage: async (input, {apiKey, model}) => {
+    console.log("prompting chat gpt...");
+    console.log("prompt: ", input);
+    const api = new ChatGPTAPI({
+      apiKey,
+      completionParams: {
+        model: "gpt-4-1106-preview",
+      },
+    });
+    const { text } = await api.sendMessage(input);
+
+    return text;
+  },
+
+  getPromptForSingleCommit: (diff, {commitType, language}) => {
+
+    return (
+      "I want you to act as the author of a commit message in git." +
+      `I'll enter a git diff, and your job is to convert it into a useful commit message in ${language} language` +
+      (commitType ? ` with commit type '${commitType}'. ` : ". ") +
+      "Do not preface the commit with anything, use the present tense, return the full sentence, and use the conventional commits specification (<type in lowercase>: <subject>): " +
+      '\n\n'+
+      diff
+    );
+  },
+
+  getPromptForMultipleCommits: (diff, {commitType, numOptions, language}) => {
+    const prompt =
+      "I want you to act as the author of a commit message in git." +
+      `I'll enter a git diff, and your job is to convert it into a useful commit message in ${language} language` +
+      (commitType ? ` with commit type '${commitType}.', ` : ", ") +
+      `and make ${numOptions} options that are separated by ";".` +
+      "For each option, use the present tense, return the full sentence, and use the conventional commits specification (<type in lowercase>: <subject>):" +
+      diff;
+
+    return prompt;
+  },
+
+  filterApi: async ({ prompt, numCompletion = 1, filterFee }) => {
+    const numTokens = encode(prompt).length;
+    const fee = numTokens / 1000 * FEE_PER_1K_TOKENS + (FEE_COMPLETION * numCompletion);
+
+    if (numTokens > MAX_TOKENS) {
+        console.log("The commit diff is too large for the ChatGPT API. Max 4k tokens or ~8k characters. ");
+        return false;
+    }
+
+    if (filterFee) {
+        console.log(`This will cost you ~$${+fee.toFixed(3)} for using the API.`);
+        const answer = await inquirer.prompt([
+            {
+                type: "confirm",
+                name: "continue",
+                message: "Do you want to continue 💸?",
+                default: true,
+            },
+        ]);
+        if (!answer.continue) return false;
+    }
+
+    return true;
+}
+
+
+};
+
+export default openai;


### PR DESCRIPTION
Hi,

I have been considering an implementation to specify a model for OpenAI's API. However, before proceeding with that, I realized it would be more efficient to split the handling of 'openai' and 'ollama' into separate files. 

## Changes made

Separation of AI_PROVIDER Logic: The conditional logic in index.js that handles different AI providers (openai and ollama) has been extracted into separate files.  This change ensures that adding a new provider in the future only requires creating a new file for it, without altering the existing codebase significantly.

This is not BREAKING CHANGE

Thanks,
