### PR TITLE
Add --message-only flag to print commit message without making a commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ You can also use the local model for free with Ollama.
 
 `--force`: Automatically create a commit without being prompted to select a message (can't be used with `--list`)
 
+`--message-only` Runs the app in a non-interactive mode, avoiding unnecessary prompts or actions beyond displaying the message.
+
 `--filter-fee`: Displays the approximate fee for using the API and prompts you to confirm the request
 
 `--apiKey`: Your OpenAI API key. It is not recommended to pass `apiKey` here, it is better to use `env` variable

--- a/index.js
+++ b/index.js
@@ -103,6 +103,11 @@ const generateSingleCommit = async (diff) => {
     return;
   }
 
+  if (args["message-only"]) {
+    console.log(finalCommitMessage);
+    process.exit(0);
+  }
+
   const answer = await inquirer.prompt([
     {
       type: "confirm",

--- a/index.js
+++ b/index.js
@@ -104,7 +104,6 @@ const generateSingleCommit = async (diff) => {
   }
 
   if (args["message-only"]) {
-    console.log(finalCommitMessage);
     process.exit(0);
   }
 


### PR DESCRIPTION
This update introduces a --message-only flag that prints the final commit message and exits without making a commit or requiring user interaction. It ensures a non-interactive mode for users who only need to view the commit message.